### PR TITLE
fix to run non sshd CMDs

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -34,7 +34,7 @@ stop() {
 }
 
 echo "Running $@"
-if [ "$(basename $@)" == "$DAEMON" ]; then
+if [ "$(basename $1)" == "$DAEMON" ]; then
     trap stop SIGINT SIGTERM
     $@ &
     pid="$!"

--- a/entry.sh
+++ b/entry.sh
@@ -34,7 +34,7 @@ stop() {
 }
 
 echo "Running $@"
-if [ "$(basename $DAEMON)" == "$DAEMON" ]; then
+if [ "$(basename $@)" == "$DAEMON" ]; then
     trap stop SIGINT SIGTERM
     $@ &
     pid="$!"


### PR DESCRIPTION
I'm a bit of a noob to this docker stuff, but I think "$(basename  $DAEMON)" will always be 'sshd', did you mean $(basename $@) ?
