### PR TITLE
example "docker run" had a wrong flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ Optionally mount a custom sshd config at `/etc/ssh/`.
 ## Usage Example
 
 ```
-docker run --d -p 2222:22 -v /secrets/id_rsa.pub:/root/.ssh/authorized_keys:ro -v /mnt/data/:/data/ quay.io/macropin/sshd
+docker run -d -p 2222:22 -v /secrets/id_rsa.pub:/root/.ssh/authorized_keys:ro -v /mnt/data/:/data/ quay.io/macropin/sshd
 ````


### PR DESCRIPTION
the example "docker run --d" was wrong. It shoud be "-d" or "--detach"
