### PR TITLE
Allow UID above 256000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 FROM docker.io/alpine:3.6
 
-MAINTAINER Andrew Cutler <andrew@panubo.com>
-
 RUN apk update && \
-    apk add bash git openssh rsync augeas && \
+    apk add bash git openssh rsync augeas shadow && \
     deluser $(getent passwd 33 | cut -d: -f1) && \
     delgroup $(getent group 33 | cut -d: -f1) 2>/dev/null || true && \
     mkdir -p ~root/.ssh /etc/authorized_keys && chmod 700 ~root/.ssh/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM docker.io/alpine:3.6
 
-LABEL maintainer="Andrew Cutler <andrew@panubo.com>"
-
 RUN apk update && \
     apk add bash git openssh rsync augeas shadow && \
     deluser $(getent passwd 33 | cut -d: -f1) && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM docker.io/alpine:3.6
 
+LABEL maintainer="Andrew Cutler <andrew@panubo.com>"
+
 RUN apk update && \
     apk add bash git openssh rsync augeas shadow && \
     deluser $(getent passwd 33 | cut -d: -f1) && \

--- a/entry.sh
+++ b/entry.sh
@@ -75,8 +75,8 @@ if [ -n "${SSH_USERS}" ]; then
         if [ ! -e "/etc/authorized_keys/${_NAME}" ]; then
             echo "WARNING: No SSH authorized_keys found for ${_NAME}!"
         fi
-        getent group ${_NAME} >/dev/null 2>&1 || /usr/sbin/groupadd -g ${_GID} ${_NAME}
-        getent passwd ${_NAME} >/dev/null 2>&1 || /usr/sbin/useradd -p x -u ${_UID} -g ${_GID} -s '' ${_NAME}
+        getent group ${_NAME} >/dev/null 2>&1 || groupadd -g ${_GID} ${_NAME}
+        getent passwd ${_NAME} >/dev/null 2>&1 || useradd -r -m -p '!' -u ${_UID} -g ${_GID} -s '' -c 'SSHD User' ${_NAME}
     done
 else
     # Warn if no authorized_keys

--- a/entry.sh
+++ b/entry.sh
@@ -75,9 +75,8 @@ if [ -n "${SSH_USERS}" ]; then
         if [ ! -e "/etc/authorized_keys/${_NAME}" ]; then
             echo "WARNING: No SSH authorized_keys found for ${_NAME}!"
         fi
-        getent group ${_NAME} >/dev/null 2>&1 || addgroup -g ${_GID} ${_NAME}
-        getent passwd ${_NAME} >/dev/null 2>&1 || adduser -D -u ${_UID} -G ${_NAME} -s '' ${_NAME}
-        passwd -u ${_NAME} || true
+        getent group ${_NAME} >/dev/null 2>&1 || /usr/sbin/groupadd -g ${_GID} ${_NAME}
+        getent passwd ${_NAME} >/dev/null 2>&1 || /usr/sbin/useradd -p x -u ${_UID} -g ${_GID} -s '' ${_NAME}
     done
 else
     # Warn if no authorized_keys


### PR DESCRIPTION
Without this change, large UIDs and GIDs cause failures such as:
```
adduser: number 2803499282 is not in 0..256000 range
```