### PR TITLE
Set correct ownership of /etc/authorized_keys/%u

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -72,11 +72,13 @@ if [ -n "${SSH_USERS}" ]; then
         _GID=${UA[2]}
 
         echo ">> Adding user ${_NAME} with uid: ${_UID}, gid: ${_GID}."
-        if [ ! -e "/etc/authorized_keys/${_NAME}" ]; then
-            echo "WARNING: No SSH authorized_keys found for ${_NAME}!"
-        fi
         getent group ${_NAME} >/dev/null 2>&1 || groupadd -g ${_GID} ${_NAME}
         getent passwd ${_NAME} >/dev/null 2>&1 || useradd -r -m -p '' -u ${_UID} -g ${_GID} -s '' -c 'SSHD User' ${_NAME}
+        if [ -e "/etc/authorized_keys/${_NAME}" ]; then
+            chown ${_NAME}: /etc/authorized_keys/${_NAME}
+        else
+            echo "WARNING: No SSH authorized_keys found for ${_NAME}!"
+        fi
     done
 else
     # Warn if no authorized_keys


### PR DESCRIPTION
The entry.sh script sets the ownership and permissions of the
/etc/authorized_keys directory and also sets the permissions of any files in
the directory to 0644. However, if this directory or any files in it are
mounted into the container as volumes, they will retain the UID/GID of the
file or directory as it exists outside of the container. sshd seems to require
that the UID of the authorized_keys file match the UID of the user logging in.

There are two possible workarounds without this change:

1. Set the UID/GID of the user's authorized_keys file before starting the
   container.
2. Set the UID/GID of the user in $SSHD_USERS to match those of the file as it
   exists outside the container.

These are not workable in every situation so this change ensures that the UID/
GID of the user's authorized_keys file match the UID/GID of the user inside the
container before starting sshd.