### PR TITLE
Run scripts/programs in /etc/entrypoint.d

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Let's say you have a docker volume mounted to `/data` inside the container. If i
 ```
 #!/bin/bash
 
-if [[ ! $(ls -A /data) ]]; then
+if [[ -z $(ls -A /data) ]]; then
     mkdir /data/foo
     mkdir /data/bar
     chown www: /data/foo /data/bar

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Please note that all components of the pathname in the ChrootDirectory directive
 
 ## Custom Scripts
 
-Executable shell scripts and binaries can be mounted or copied  to `/etc/entrypoint.d` inside the container. These scripts will be run when the container is launched but before sshd is started. A common use case is to adjust the ownership and permissions of files (for example, public SSH keys) so that sshd will read them.
+Executable shell scripts and binaries can be mounted or copied in to `/etc/entrypoint.d`. These will be run when the container is launched but before sshd is started. These can be used to customise the behaviour of the container.
 
 ## Usage Example
 
@@ -45,38 +45,6 @@ or
 
 ```
 docker run -d -p 2222:22 -v $(pwd)/.ssh/id_rsa.pub:/etc/authorized_keys/www -e SSH_USERS="www:48:48" docker.io/panubo/sshd:1.0.3
-```
-
-### Custom Script Example
-
-Let's say you have a docker volume mounted to `/data` inside the container. If it's empty, it should be populated with subdirectories owned by the `www` user. You could do that with this script, called `provision_data.sh`:
-
-```
-#!/bin/bash
-
-if [[ -z $(ls -A /data) ]]; then
-    mkdir /data/foo
-    mkdir /data/bar
-    chown www: /data/foo /data/bar
-fi
-```
-
-Make sure it is execuable:
-
-```
-$ chmod ugo+x provision_data.sh
-```
-
-And then bind-mount it in when starting the container:
-
-```
-$ docker run -d \
-    -p 2222:22 \
-    -v $(pwd)/.ssh/id_rsa.pub:/etc/authorized_keys/www
-    -v $(pwd)/data:/data \
-    -v $(pwd)/provision_data.sh:/etc/entrypoint.d/provision_data.sh \
-    -e SSH_USERS="www:48:48" \
-    docker.io/panubo/sshd
 ```
 
 ## Status

--- a/entry.sh
+++ b/entry.sh
@@ -116,6 +116,15 @@ if [[ "${GATEWAY_PORTS}" == "true" ]]; then
     echo 'set /files/etc/ssh/sshd_config/GatewayPorts yes' | augtool -s
 fi
 
+# Run scripts in /etc/entrypoint.d
+for f in /etc/entrypoint.d/*; do
+    if [[ -x ${f} ]]; then
+        echo "Running: ${f}"
+        ${f}
+    fi
+done
+
+
 stop() {
     echo "Received SIGINT or SIGTERM. Shutting down $DAEMON"
     # Get PID

--- a/entry.sh
+++ b/entry.sh
@@ -119,11 +119,10 @@ fi
 # Run scripts in /etc/entrypoint.d
 for f in /etc/entrypoint.d/*; do
     if [[ -x ${f} ]]; then
-        echo "Running: ${f}"
+        echo ">> Running: ${f}"
         ${f}
     fi
 done
-
 
 stop() {
     echo "Received SIGINT or SIGTERM. Shutting down $DAEMON"


### PR DESCRIPTION
Sometimes it is useful to add scripts or binaries to an image which will be run
automatically when the container is launched but before it starts the main
daemon or service. These can be added by a descendent image or by being
bind-mounted into the container at runtime. This saves having to fork the whole
repo just make a very minor change to entry.sh. This is a rather common pattern
in some of the more popular images on Docker Hub. I feel it makes sense for a
fairly general-purpose image like this one as well.