### PR TITLE
Bump alpine to v3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.6
+FROM alpine:3.10
 
 RUN apk update && \
     apk add bash git openssh rsync augeas shadow && \


### PR DESCRIPTION
Alpine 3.6 is [EOL since 1st May 2019](https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases) and doesn't get security fixes anymore. This pull request will also solve #25.

I verified SSH login is still possible after version bump. This seems to work as expected. Didn't test `rsync`, but as it's a "clean" install, I don't expect any issues.

Updated PR of #34 