### PR TITLE
sighup and fix return code when error

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -178,7 +178,8 @@ if [ "$(basename $1)" == "$DAEMON" ]; then
     $@ &
     pid="$!"
     mkdir -p /var/run/$DAEMON && echo "${pid}" > /var/run/$DAEMON/$DAEMON.pid
-    wait "${pid}" && exit $?
+    wait "${pid}"
+    exit $?
 else
     exec "$@"
 fi


### PR DESCRIPTION
I fix the last line waiting for process to exit and then exit with return exit code. The `&&` make the exit code visible only if the exit code was `0`.