### PR TITLE
Feature: Add rssh to restrict scp and rsync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10
 
 RUN apk update && \
-    apk add bash git openssh rsync augeas shadow && \
+    apk add bash git openssh rsync augeas shadow rssh && \
     deluser $(getent passwd 33 | cut -d: -f1) && \
     delgroup $(getent group 33 | cut -d: -f1) 2>/dev/null || true && \
     mkdir -p ~root/.ssh /etc/authorized_keys && chmod 700 ~root/.ssh/ && \

--- a/README.md
+++ b/README.md
@@ -6,15 +6,33 @@ Minimal Alpine Linux Docker image with `sshd` exposed and `rsync` installed.
 
 Configure the container with the following environment variables or optionally mount a custom sshd config at `/etc/ssh/sshd_config`:
 
+### General Options
+
 - `SSH_USERS` list of user accounts and uids/gids to create. eg `SSH_USERS=www:48:48,admin:1000:1000`
 - `SSH_ENABLE_ROOT` if "true" unlock the root account
 - `SSH_ENABLE_PASSWORD_AUTH` if "true" enable password authentication (disabled by default)
 - `MOTD` change the login message
-- `SFTP_MODE` if "true" sshd will only accept sftp connections
-- `SFTP_CHROOT` if in sftp only mode sftp will be chrooted to this directory. Default "/data"
-- `SCP_MODE` if "true" sshd will only accept scp connections
+
+### SSH Options
+
 - `GATEWAY_PORTS` if "true" sshd will allow gateway ports
 - `TCP_FORWARDING` if "true" sshd will allow TCP forwarding
+
+The following three optional modes, SFTP, SCP and Rsync are mutually exclusive. Only one can be
+enabled at a time:
+
+### SFTP Only
+
+- `SFTP_MODE` if "true" sshd will only accept sftp connections
+- `SFTP_CHROOT` if in sftp only mode sftp will be chrooted to this directory. Default "/data"
+
+### SCP Only
+
+- `SCP_MODE` if "true" sshd will only accept scp connections (uses rssh)
+
+### Rsync Only
+
+- `RSYNC_MODE` if "true" sshd will only accept rsync connections (uses rssh)
 
 ## SSH Host Keys
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Configure the container with the following environment variables or optionally m
 - `MOTD` change the login message
 - `SFTP_MODE` if "true" sshd will only accept sftp connections
 - `SFTP_CHROOT` if in sftp only mode sftp will be chrooted to this directory. Default "/data"
+- `SCP_MODE` if "true" sshd will only accept scp connections
 - `GATEWAY_PORTS` if "true" sshd will allow gateway ports
 - `TCP_FORWARDING` if "true" sshd will allow TCP forwarding
 
@@ -34,9 +35,15 @@ uid/gid and user specified in `SSH_USERS`.
 
 ## SFTP mode
 
-When in sftp only mode (activated by setting `SFTP_MODE=true` the container will only accept sftp connections. All sftp actions will be chrooted to the `SFTP_CHROOT` directory which defaults to "/data".
+When in sftp only mode (activated by setting `SFTP_MODE=true`) the container will only accept sftp connections. All sftp actions will be chrooted to the `SFTP_CHROOT` directory which defaults to "/data".
 
 Please note that all components of the pathname in the ChrootDirectory directive must be root-owned directories that are not writable by any other user or group (see `man 5 sshd_config`).
+
+## SCP mode
+
+When in scp only mode (activated by setting `SCP_MODE=true`) the container will only accept scp connections. No chroot provided.
+
+This is provided using [rssh](http://www.pizzashack.org/rssh/) restricted shell.
 
 ## Custom Scripts
 

--- a/entry.sh
+++ b/entry.sh
@@ -141,6 +141,13 @@ if [[ "${SFTP_MODE}" == "true" ]]; then
         'set /files/etc/ssh/sshd_config/ForceCommand internal-sftp' \
         "set /files/etc/ssh/sshd_config/ChrootDirectory ${SFTP_CHROOT}" \
     | augtool -s 1> /dev/null
+elif [[ "${SCP_MODE}" == "true" ]]; then
+    USERS=$(echo $SSH_USERS | tr "," "\n")
+    for U in $USERS; do
+        _NAME=$(echo "${U}" | cut -d: -f1)
+        usermod -s '/usr/bin/rssh' ${_NAME}
+    done
+    (grep '^[a-zA-Z]' /etc/rssh.conf.default; echo "allowscp") > /etc/rssh.conf
 else
     # Enable AllowTcpForwarding
     if [[ "${TCP_FORWARDING}" == "true" ]]; then

--- a/entry.sh
+++ b/entry.sh
@@ -129,10 +129,10 @@ fi
 
 # SFTP only mode
 if [[ "${SFTP_MODE}" == "true" ]]; then
+    echo "INFO: configuring sftp only mode"
     : ${SFTP_CHROOT:='/data'}
     chown 0:0 ${SFTP_CHROOT}
     chmod 755 ${SFTP_CHROOT}
-
     printf '%s\n' \
         'set /files/etc/ssh/sshd_config/Subsystem/sftp "internal-sftp"' \
         'set /files/etc/ssh/sshd_config/AllowTCPForwarding no' \
@@ -142,12 +142,21 @@ if [[ "${SFTP_MODE}" == "true" ]]; then
         "set /files/etc/ssh/sshd_config/ChrootDirectory ${SFTP_CHROOT}" \
     | augtool -s 1> /dev/null
 elif [[ "${SCP_MODE}" == "true" ]]; then
+  echo "INFO: configuring scp only mode"
     USERS=$(echo $SSH_USERS | tr "," "\n")
     for U in $USERS; do
         _NAME=$(echo "${U}" | cut -d: -f1)
         usermod -s '/usr/bin/rssh' ${_NAME}
     done
     (grep '^[a-zA-Z]' /etc/rssh.conf.default; echo "allowscp") > /etc/rssh.conf
+elif [[ "${RSYNC_MODE}" == "true" ]]; then
+  echo "INFO: configuring rsync only mode"
+    USERS=$(echo $SSH_USERS | tr "," "\n")
+    for U in $USERS; do
+        _NAME=$(echo "${U}" | cut -d: -f1)
+        usermod -s '/usr/bin/rssh' ${_NAME}
+    done
+    (grep '^[a-zA-Z]' /etc/rssh.conf.default; echo "allowrsync") > /etc/rssh.conf
 else
     # Enable AllowTcpForwarding
     if [[ "${TCP_FORWARDING}" == "true" ]]; then


### PR DESCRIPTION
Added option to restrict on scp and rsync. Reformatted docs to make the distinct modes more clear.

Closes #43 