### PR TITLE
Remove postgres uid (70) and gid (70)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ RUN apk update && \
     apk add bash git openssh rsync augeas shadow rssh && \
     deluser $(getent passwd 33 | cut -d: -f1) && \
     delgroup $(getent group 33 | cut -d: -f1) 2>/dev/null || true && \
+    deluser $(getent passwd 70 | cut -d: -f1) && \ \
+    delgroup $(getent group 70 | cut -d: -f1) 2>/dev/null || true && \
     mkdir -p ~root/.ssh /etc/authorized_keys && chmod 700 ~root/.ssh/ && \
     augtool 'set /files/etc/ssh/sshd_config/AuthorizedKeysFile ".ssh/authorized_keys /etc/authorized_keys/%u"' && \
     echo -e "Port 22\n" >> /etc/ssh/sshd_config && \


### PR DESCRIPTION
Updated Dockerfile to remove postgres user and group, it allows to attach container to an exiting PostreSQL container.