### PR TITLE
Update to Alpine release 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.11
 
 RUN apk update && \
     apk add bash git openssh rsync augeas shadow rssh && \


### PR DESCRIPTION
Updated Alpine version to 3.11 and successfully launched a container from the resulting image. 