### PR TITLE
Dockerfile Improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
 FROM alpine:3.12
 
-RUN apk update && \
-    apk add bash git openssh rsync augeas shadow rssh && \
-    deluser $(getent passwd 33 | cut -d: -f1) && \
-    delgroup $(getent group 33 | cut -d: -f1) 2>/dev/null || true && \
-    mkdir -p ~root/.ssh /etc/authorized_keys && chmod 700 ~root/.ssh/ && \
+RUN apk add --no-cache bash
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apk add --no-cache "git" "openssh" "rsync" "augeas" "shadow" "rssh" && \
+    deluser "$(getent passwd 33 | cut -d: -f1)" && \
+    delgroup "$(getent group 33 | cut -d: -f1)" 2>/dev/null || true && \
+    mkdir -p '~root/.ssh' '/etc/authorized_keys' && chmod 700 '~root/.ssh/' && \
     augtool 'set /files/etc/ssh/sshd_config/AuthorizedKeysFile ".ssh/authorized_keys /etc/authorized_keys/%u"' && \
-    echo -e "Port 22\n" >> /etc/ssh/sshd_config && \
-    cp -a /etc/ssh /etc/ssh.cache && \
-    rm -rf /var/cache/apk/*
+    echo -e "Port 22\n" >> '/etc/ssh/sshd_config' && \
+    cp -a '/etc/ssh' '/etc/ssh.cache'
 
 EXPOSE 22
 


### PR DESCRIPTION
- Bump alpine 3.12.
- Use `apk add --no-cache` instead of `apk update && apk install && rm -rf /var/cache/apk`.
- https://github.com/docker/docker.github.io/blob/master/develop/develop-images/dockerfile_best-practices.md#using-pipes, since there are some shells that do not accept the `-o pipefail` option, it is not enough to add set `-o pipefail` inside the RUN instruction. Therefore, we recommend to always explicitly the SHELL before using pipes in RUN (https://github.com/hadolint/hadolint/wiki/DL4006#rationale).
- Quote to prevent word splitting.