### PR TITLE
add support for specifying user shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Configure the container with the following environment variables or optionally m
 
 ### General Options
 
-- `SSH_USERS` list of user accounts and uids/gids to create. eg `SSH_USERS=www:48:48,admin:1000:1000`
+- `SSH_USERS` list of user accounts and uids/gids to create. eg `SSH_USERS=www:48:48,admin:1000:1000:/bin/bash`. The fourth argument for specifying the user shell is optional
 - `SSH_ENABLE_ROOT` if "true" unlock the root account
 - `SSH_ENABLE_PASSWORD_AUTH` if "true" enable password authentication (disabled by default)
 - `MOTD` change the login message

--- a/entry.sh
+++ b/entry.sh
@@ -91,7 +91,7 @@ if [ -n "${SSH_USERS}" ]; then
         if [ ${#UA[*]} -eq 4 ]; then
             _SHELL=${UA[3]}
         else
-          _SHELL=''
+            _SHELL=''
         fi
 
         echo ">> Adding user ${_NAME} with uid: ${_UID}, gid: ${_GID}, shell: ${_SHELL:-<default>}."
@@ -101,7 +101,7 @@ if [ -n "${SSH_USERS}" ]; then
             check_authorized_key_ownership /etc/authorized_keys/${_NAME} ${_UID} ${_GID}
         fi
         getent group ${_NAME} >/dev/null 2>&1 || groupadd -g ${_GID} ${_NAME}
-        getent passwd ${_NAME} >/dev/null 2>&1 || useradd -r -m -p '' -u ${_UID} -g ${_GID} -s ${_SHELL:-\'\'} -c 'SSHD User' ${_NAME}
+        getent passwd ${_NAME} >/dev/null 2>&1 || useradd -r -m -p '' -u ${_UID} -g ${_GID} -s ${_SHELL:-""} -c 'SSHD User' ${_NAME}
     done
 else
     # Warn if no authorized_keys

--- a/entry.sh
+++ b/entry.sh
@@ -88,7 +88,7 @@ if [ -n "${SSH_USERS}" ]; then
         _NAME=${UA[0]}
         _UID=${UA[1]}
         _GID=${UA[2]}
-        if [ ${#UA[*]} -eq 4 ]; then
+        if [ ${#UA[*]} -ge 4 ]; then
             _SHELL=${UA[3]}
         else
             _SHELL=''

--- a/entry.sh
+++ b/entry.sh
@@ -90,6 +90,8 @@ if [ -n "${SSH_USERS}" ]; then
         _GID=${UA[2]}
         if [ ${#UA[*]} -eq 4 ]; then
             _SHELL=${UA[3]}
+        else
+          _SHELL=''
         fi
 
         echo ">> Adding user ${_NAME} with uid: ${_UID}, gid: ${_GID}, shell: ${_SHELL:-<default>}."

--- a/entry.sh
+++ b/entry.sh
@@ -90,8 +90,6 @@ if [ -n "${SSH_USERS}" ]; then
         _GID=${UA[2]}
         if [ ${#UA[*]} -eq 4 ]; then
             _SHELL=${UA[3]}
-        else
-            _SHELL=''
         fi
 
         echo ">> Adding user ${_NAME} with uid: ${_UID}, gid: ${_GID}, shell: ${_SHELL:-<default>}."
@@ -101,7 +99,7 @@ if [ -n "${SSH_USERS}" ]; then
             check_authorized_key_ownership /etc/authorized_keys/${_NAME} ${_UID} ${_GID}
         fi
         getent group ${_NAME} >/dev/null 2>&1 || groupadd -g ${_GID} ${_NAME}
-        getent passwd ${_NAME} >/dev/null 2>&1 || useradd -r -m -p '' -u ${_UID} -g ${_GID} -s ${_SHELL} -c 'SSHD User' ${_NAME}
+        getent passwd ${_NAME} >/dev/null 2>&1 || useradd -r -m -p '' -u ${_UID} -g ${_GID} -s ${_SHELL:-\'\'} -c 'SSHD User' ${_NAME}
     done
 else
     # Warn if no authorized_keys

--- a/entry.sh
+++ b/entry.sh
@@ -88,15 +88,20 @@ if [ -n "${SSH_USERS}" ]; then
         _NAME=${UA[0]}
         _UID=${UA[1]}
         _GID=${UA[2]}
+        if [ ${#UA[*]} -eq 4 ]; then
+            _SHELL=${UA[3]}
+        else
+            _SHELL=''
+        fi
 
-        echo ">> Adding user ${_NAME} with uid: ${_UID}, gid: ${_GID}."
+        echo ">> Adding user ${_NAME} with uid: ${_UID}, gid: ${_GID}, shell: ${_SHELL:-<default>}."
         if [ ! -e "/etc/authorized_keys/${_NAME}" ]; then
             echo "WARNING: No SSH authorized_keys found for ${_NAME}!"
         else
             check_authorized_key_ownership /etc/authorized_keys/${_NAME} ${_UID} ${_GID}
         fi
         getent group ${_NAME} >/dev/null 2>&1 || groupadd -g ${_GID} ${_NAME}
-        getent passwd ${_NAME} >/dev/null 2>&1 || useradd -r -m -p '' -u ${_UID} -g ${_GID} -s '' -c 'SSHD User' ${_NAME}
+        getent passwd ${_NAME} >/dev/null 2>&1 || useradd -r -m -p '' -u ${_UID} -g ${_GID} -s ${_SHELL} -c 'SSHD User' ${_NAME}
     done
 else
     # Warn if no authorized_keys


### PR DESCRIPTION
Add support for changing the user shell. Useful for building a bastion or captive shell.