### PR TITLE
Add Dockerfiles for arm32v7 and arm64v8

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,4 +1,4 @@
-FROM arm32v7/alpine:3.12
+FROM alpine:3.12
 
 RUN apk update && \
     apk add bash git openssh rsync augeas shadow rssh && \

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,0 +1,19 @@
+FROM arm64v8/alpine:3.12
+
+RUN apk update && \
+    apk add bash git openssh rsync augeas shadow rssh && \
+    deluser $(getent passwd 33 | cut -d: -f1) && \
+    delgroup $(getent group 33 | cut -d: -f1) 2>/dev/null || true && \
+    mkdir -p ~root/.ssh /etc/authorized_keys && chmod 700 ~root/.ssh/ && \
+    augtool 'set /files/etc/ssh/sshd_config/AuthorizedKeysFile ".ssh/authorized_keys /etc/authorized_keys/%u"' && \
+    echo -e "Port 22\n" >> /etc/ssh/sshd_config && \
+    cp -a /etc/ssh /etc/ssh.cache && \
+    rm -rf /var/cache/apk/*
+
+EXPOSE 22
+
+COPY entry.sh /entry.sh
+
+ENTRYPOINT ["/entry.sh"]
+
+CMD ["/usr/sbin/sshd", "-D", "-e", "-f", "/etc/ssh/sshd_config"]


### PR DESCRIPTION
This PR adds dockerfiles that are used in this repo:  https://hub.docker.com/repository/docker/guysoft/sshd

They are used to provide this service for a raspsberrypi 2B to 4B versions.
