### PR TITLE
fixed problem where only one user with one group can be used

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -100,7 +100,7 @@ if [ -n "${SSH_USERS}" ]; then
         else
             check_authorized_key_ownership /etc/authorized_keys/${_NAME} ${_UID} ${_GID}
         fi
-        getent group ${_NAME} >/dev/null 2>&1 || groupadd -g ${_GID} ${_NAME}
+        getent group ${_NAME} >/dev/null 2>&1 || groupadd -f -g ${_GID} ${_NAME}
         getent passwd ${_NAME} >/dev/null 2>&1 || useradd -r -m -p '' -u ${_UID} -g ${_GID} -s ${_SHELL:-""} -c 'SSHD User' ${_NAME}
     done
 else


### PR DESCRIPTION
If you want to use env variable

SSH_USERS: "test:1000:1000, test2:1001:1000" 

this is not possible as the groupadd without -f raises a none zero exit code crashing the entry point script