### PR TITLE
Add multi-arch support (Docker buildx)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
 NAME := sshd
+USER := panubo
+
 TAG := latest
-IMAGE_NAME := panubo/$(NAME)
+IMAGE_NAME := $(USER)/$(NAME)
+
+DOCKER := docker
+
+ARCH_LIST := linux/amd64 linux/386 linux/arm64 linux/ppc64le linux/s390x linux/arm/v7 linux/arm/v6
+comma := ,
+COM_ARCH_LIST:= $(subst $() $(),$(comma),$(ARCH_LIST))
 
 .PHONY: help build push clean
 
@@ -8,15 +16,19 @@ help:
 	@printf "$$(grep -hE '^\S+:.*##' $(MAKEFILE_LIST) | sed -e 's/:.*##\s*/:/' -e 's/^\(.\+\):\(.*\)/\\x1b[36m\1\\x1b[m:\2/' | column -c2 -t -s :)\n"
 
 build: ## Builds docker image latest
-	docker build --pull -t $(IMAGE_NAME):latest .
+	$(DOCKER) build --pull -t $(IMAGE_NAME):latest .
 
-push: ## Pushes the docker image to hub.docker.com
+push: qemu ## Pushes the docker image to hub.docker.com
 	# Don't --pull here, we don't want any last minute upsteam changes
-	docker build -t $(IMAGE_NAME):$(TAG) .
-	docker tag $(IMAGE_NAME):$(TAG) $(IMAGE_NAME):latest
-	docker push $(IMAGE_NAME):$(TAG)
-	docker push $(IMAGE_NAME):latest
+	$(DOCKER) buildx build . -t $(IMAGE_NAME):$(TAG) -t $(IMAGE_NAME):latest \
+	--platform $(COM_ARCH_LIST) --push
+
+qemu:
+	export DOCKER_CLI_EXPERIMENTAL=enabled
+	$(DOCKER) run --rm --privileged multiarch/qemu-user-static --reset -p yes
+	$(DOCKER) buildx create --name qemu_builder --driver docker-container --use || true
+	$(DOCKER) buildx inspect --bootstrap
 
 clean: ## Remove built images
-	docker rmi $(IMAGE_NAME):latest || true
-	docker rmi $(IMAGE_NAME):$(TAG) || true
+	$(DOCKER) rmi $(IMAGE_NAME):latest || true
+	$(DOCKER) rmi $(IMAGE_NAME):$(TAG) || true


### PR DESCRIPTION
Add multi-arch support (docker Buildx)
- linux/amd64
- linux/386
- linux/arm64
- linux/ppc64le
- linux/s390x
- linux/arm/v7
- linux/arm/v6

Issue: #59

**Edit: In a future PR, I would add a workflow for build and test to each push (or do I do it in this PR ?)**

Signed-off-by: Bensuperpc <bensuperpc@gmail.com>