### PR TITLE
Added group creation option and corresponding documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Configure the container with the following environment variables or optionally m
 
 ### General Options
 
-- `SSH_USERS` list of user accounts and uids/gids to create. eg `SSH_USERS=www:48:48,admin:1000:1000:/bin/bash`. The fourth argument for specifying the user shell is optional
+- `SSH_USERS` list of user accounts and uids/gids to create. eg `SSH_USERS=www:48:48,admin:1000:1000:/bin/bash`. The fourth argument for specifying the user shell is optional. If `SSH_GROUPS` is omitted, a group is created for each user with the same name as the user.
+- `SSH_GROUPS` list of groups and gids to create. eg `SSH_GROUPS=guests:1005,other:1006`. Specifying this option disables automatic group creation of user-named groups if you also specify `SSH_USERS`.
 - `SSH_ENABLE_ROOT` if "true" unlock the root account
 - `SSH_ENABLE_PASSWORD_AUTH` if "true" enable password authentication (disabled by default) (excluding the root user)
 - `SSH_ENABLE_ROOT_PASSWORD_AUTH` if "true" enable password authentication for all users including root

--- a/entry.sh
+++ b/entry.sh
@@ -81,7 +81,6 @@ fi
 
 # Add groups if SSH_GROUPS=group:gid set
 if [ -n "${SSH_GROUPS}" ]; then
-    USERS=$(echo $SSH_USERS | tr "," "\n")
     GROUPZ=$(echo $SSH_GROUPS | tr "," "\n")
     for G in $GROUPZ; do
         IFS=':' read -ra GA <<< "$G"

--- a/entry.sh
+++ b/entry.sh
@@ -79,6 +79,19 @@ if [ -w /etc/authorized_keys ]; then
     done
 fi
 
+# Add groups if SSH_GROUPS=group:gid set
+if [ -n "${SSH_GROUPS}" ]; then
+    USERS=$(echo $SSH_USERS | tr "," "\n")
+    GROUPZ=$(echo $SSH_GROUPS | tr "," "\n")
+    for G in $GROUPZ; do
+        IFS=':' read -ra GA <<< "$G"
+        _NAME=${GA[0]}
+        _GID=${GA[1]}
+        echo ">> Adding group ${_NAME} with gid: ${_GID}."
+        getent group ${_NAME} >/dev/null 2>&1 || groupadd -g ${_GID} ${_NAME}
+    done
+fi
+
 # Add users if SSH_USERS=user:uid:gid set
 if [ -n "${SSH_USERS}" ]; then
     USERS=$(echo $SSH_USERS | tr "," "\n")
@@ -99,7 +112,9 @@ if [ -n "${SSH_USERS}" ]; then
         else
             check_authorized_key_ownership /etc/authorized_keys/${_NAME} ${_UID} ${_GID}
         fi
-        getent group ${_NAME} >/dev/null 2>&1 || groupadd -g ${_GID} ${_NAME}
+        if [ -z "${SSH_GROUPS}" ]; then
+            getent group ${_NAME} >/dev/null 2>&1 || groupadd -g ${_GID} ${_NAME}
+        fi
         getent passwd ${_NAME} >/dev/null 2>&1 || useradd -r -m -p '' -u ${_UID} -g ${_GID} -s ${_SHELL:-""} -c 'SSHD User' ${_NAME}
     done
 else


### PR DESCRIPTION
Added a new config option `SSH_GROUPS`, which is a list of groups and GIDs to create. These groups will be created before the users are created (assuming `SSH_USERS` is also specified). Specifying this option disables automatic group creation of user-named groups if you also specify `SSH_USERS` since it's assumed you want greater control in this case.

My use case is such that my users are all members of one group, so this lets me create the group first, then create the users and set their GIDs to the group I just created.