### PR TITLE
fix: handle read-only authorized_keys files without failing from -e

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -78,7 +78,9 @@ if [ -w /etc/authorized_keys ]; then
     chmod 755 /etc/authorized_keys
     # test for writability before attempting chmod
     find /etc/authorized_keys/ -type f -maxdepth 1 -print0 | while IFS= read -r -d '' f; do
-        [ -w "${f}" ] && chmod 644 "${f}"
+        if [ -w "${f}" ]; then
+            chmod 644 "${f}"
+        fi
     done
 fi
 


### PR DESCRIPTION
I'm using this container in a kubernetes homelab and am mounting individual keys into `/etc/authorized_keys` rather than mounting the entire filesystem. The `[ test ] &&` form triggers a failure because of `set -e`, this changes it to use if/then instead to continue startup.